### PR TITLE
[commhistory-daemon] Don't create new events for echoed delivery reports

### DIFF
--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -692,12 +692,7 @@ void TextChannelListener::handleMessages()
                     modifyTokens[groupId].insertMulti(event.id(), token);
 
                 } else {
-                    // recovered message should be added
-                    addEvents << event;
-                    addMessages << message;
-                    // expunging of added message will fail, but it's harmless
-                    // and we don't need to expung this delivery report cause
-                    // tp-ring do it automatically if the status is accepted
+                    qDebug() << __PRETTY_FUNCTION__ << "Ignoring recovered message from delivery echo";
                 }
 
                 break;


### PR DESCRIPTION
This tends to just result in duplicated events in the conversation,
especially for Facebook IM (which has an especially bad echo system).
