### PR TITLE
Update existing outgoing message events when reported as sent by telepathy

### DIFF
--- a/src/textchannellistener.h
+++ b/src/textchannellistener.h
@@ -168,7 +168,7 @@ private:
                           int groupId, CommHistory::Event &event);
     bool getEventById(int eventId, CommHistory::Event &event);
 
-    void saveNewMessage(CommHistory::Event &event);
+    void saveMessage(CommHistory::Event &event);
     virtual void finishedWithError(const QString& errorName, const QString& errorMessage);
 
     bool hasPendingOperations() const;


### PR DESCRIPTION
The first part of this change refactors getEventForToken to be synchronous, which it would be anyway. The asynchronous logic was broken and awkwardly inflexible. A corresponding getEventById method was also added.

The second part updates pre-existing events when outgoing messages are accepted by telepathy. That fixes message tokens and some IM error cases for outgoing messages.
