### PR TITLE
[commhistoryd] Use mce directly to turn the screen on when displaying a ...

### DIFF
--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -15,7 +15,7 @@ BuildRequires:  pkgconfig(commhistory-qt5)
 BuildRequires:  pkgconfig(TelepathyQt5)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(mlocale5)
-BuildRequires:  pkgconfig(qmsystem2-qt5)
+BuildRequires:  pkgconfig(mce)
 BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -39,9 +39,6 @@
 #include <QContactFetchRequest>
 #include <QContactFilter>
 
-//QmSystem2
-#include <qmdisplaystate.h>
-
 #include <CommHistory/Event>
 #include <CommHistory/Group>
 
@@ -154,7 +151,6 @@ private:
 
     NotificationManager( QObject* parent = 0);
     ~NotificationManager();
-    void undimScreen();
     bool isCurrentlyObservedByUI(const CommHistory::Event& event,
                                  const QString &channelTargetId,
                                  CommHistory::Group::ChatType chatType);
@@ -248,7 +244,6 @@ private:
     QTimer m_ContactsTimer;
 
     MWIListener *m_pMWIListener;
-    MeeGo::QmDisplayState *m_pDisplayState;
     Ngf::Client *m_ngfClient;
     quint32 m_ngfEvent;
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -35,7 +35,7 @@ QT += dbus contacts versit
 
 CONFIG += debug
 
-PKGCONFIG += qmsystem2-qt5 ngf-qt5
+PKGCONFIG += ngf-qt5 mce
 PKGCONFIG += TelepathyQt5 commhistory-qt5 mlite5 mlocale5
 # clock_gettime
 LIBS += -lrt

--- a/tests/tests.pri
+++ b/tests/tests.pri
@@ -30,7 +30,7 @@ TEMPLATE     = app
 INCLUDEPATH += . .. \
                ../../src
 
-PKGCONFIG += mlite5 commhistory-qt5 qmsystem2-qt5
+PKGCONFIG += mlite5 commhistory-qt5
 
 COMMHISTORYDSRCDIR = ../../src
 DEPENDPATH  += $${INCLUDEPATH}

--- a/tests/ut_notificationmanager/ut_notificationmanager.pro
+++ b/tests/ut_notificationmanager/ut_notificationmanager.pro
@@ -34,7 +34,7 @@
 #-----------------------------------------------------------------------------
 TARGET = ut_notificationmanager
 
-PKGCONFIG += mlocale5 qmsystem2-qt5 TelepathyQt5 ngf-qt5
+PKGCONFIG += mlocale5 TelepathyQt5 ngf-qt5
 
 TEST_SOURCES += $$COMMHISTORYDSRCDIR/notificationmanager.cpp \
                 $$COMMHISTORYDSRCDIR/notificationgroup.cpp \


### PR DESCRIPTION
...notification.

There is nothing to be gained by using qmsystem for this. In addition, we just
immediately request that the screen be turned on rather than checking if it is
on first: this avoids a blocking DBus call to mce.
