### PR TITLE
[commhistory-daemon] Fix name for the Telepathy SMS channel interface

### DIFF
--- a/src/TpExtensions/Constants
+++ b/src/TpExtensions/Constants
@@ -3,9 +3,5 @@
 
 #include "TpExtensions/.gen/constants.h"
 
-// Don't add all the stuff for channel interfaces just for this define.
-#define COMM_HISTORY_TP_INTERFACE_CHANNEL_INTERFACE_SMS \
-    "com.nokia.Telepathy.Channel.Interface.SMS"
-
 #endif
 // vim:set ft=cpp:

--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -47,10 +47,10 @@
 #include <TelepathyQt/Connection>
 #include <TelepathyQt/Properties>
 #include <TelepathyQt/Presence>
+#include <TelepathyQt/Constants>
 #include <TelepathyQt/types.h>
 
 #include <TpExtensions/Connection> // stored messages if
-#include <TpExtensions/Constants> // Flash sms
 
 // Contacts
 #include <QContact>
@@ -288,7 +288,7 @@ void TextChannelListener::channelListenerReady()
         // check if channel is meant to be used for class 0 sms messages
         QVariantMap properties = textChannel->immutableProperties();
 
-        QVariant property = properties.value(QLatin1String(COMM_HISTORY_TP_INTERFACE_CHANNEL_INTERFACE_SMS ".Flash"), QVariant());
+        QVariant property = properties.value(TP_QT_IFACE_CHANNEL_INTERFACE_SMS + QLatin1String(".Flash"), QVariant());
         if(property.isValid() && property.value<bool>() == true) {
             DEBUG() << __FUNCTION__ << "Channel contains class 0 property";
             m_isClassZeroSMS = true;

--- a/tests/stubs/TelepathyQt/constants.h
+++ b/tests/stubs/TelepathyQt/constants.h
@@ -3472,6 +3472,14 @@ const int NUM_MEDIA_STREAM_TRANSPORT_TYPES = (2+1);
 /**
  * \ingroup ifacestrconsts
  *
+ * The interface name "org.freedesktop.Telepathy.Channel.Interface.SMS" as a QLatin1String, usable in QString requiring contexts even when
+ * building with Q_NO_CAST_FROM_ASCII defined.
+ */
+#define TP_QT_IFACE_CHANNEL_INTERFACE_SMS (QLatin1String("org.freedesktop.Telepathy.Channel.Interface.SMS"))
+
+/**
+ * \ingroup ifacestrconsts
+ *
  * The interface name "org.freedesktop.Telepathy.Channel.Interface.Tube".
  */
 #define TELEPATHY_INTERFACE_CHANNEL_INTERFACE_TUBE "org.freedesktop.Telepathy.Channel.Interface.Tube"


### PR DESCRIPTION
This was promoted to the real specification, so it's included in TelepathyQt and under org.freedesktop now, not com.nokia.

I updated the test stub directly, since we don't have a way to regenerate those. I'm going to separately investigate if they're actually useful for anything, and remove them if not, because they're very outdated.
