### PR TITLE
[commhistory-daemon] Play the SMS sound and turn on screen for class 0

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -386,6 +386,19 @@ void NotificationManager::showNotification(const CommHistory::Event& event,
     }
 }
 
+void NotificationManager::playClass0SMSAlert()
+{
+    if (!m_ngfClient->isConnected())
+        m_ngfClient->connect();
+
+    m_ngfEvent = m_ngfClient->play(QLatin1Literal("sms"));
+
+    // ask mce to undim the screen
+    QString mceMethod = QString::fromLatin1(MCE_DISPLAY_ON_REQ);
+    QDBusMessage msg = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, mceMethod);
+    QDBusConnection::systemBus().call(msg, QDBus::NoBlock);
+}
+
 bool NotificationManager::isCurrentlyObservedByUI(const CommHistory::Event& event,
                                                   const QString &channelTargetId,
                                                   CommHistory::Group::ChatType chatType)

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -108,6 +108,11 @@ public:
     void showVoicemailNotification(int count);
 
     /*!
+     * \brief Play class 0 SMS alert
+     */
+    void playClass0SMSAlert();
+
+    /*!
      * \brief Get the QContactManager.
      */
     QContactManager* contactManager();

--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -760,6 +760,7 @@ void TextChannelListener::handleMessages()
                 processedMessages << message;
                 classZeroSMSModel()->addEvent(event,true);
                 m_EventTokens.insertMulti(event.id(), event.messageToken());
+                nManager->playClass0SMSAlert();
             // Replace sms
             } else if (!replaceTypeValue.isEmpty()) {
                 DEBUG() << __FUNCTION__ << "Replace type of sms";

--- a/tests/stubs/notificationmanager.cpp
+++ b/tests/stubs/notificationmanager.cpp
@@ -50,6 +50,10 @@ void NotificationManager::showVoicemailNotification(int count)
     voicemailNotifications = count;
 }
 
+void NotificationManager::playClass0SMSAlert()
+{
+}
+
 CommHistory::GroupModel* NotificationManager::groupModel()
 {
     return m_GroupModel;

--- a/tests/stubs/notificationmanager.h
+++ b/tests/stubs/notificationmanager.h
@@ -30,6 +30,7 @@ public:
 
     CommHistory::GroupModel* groupModel();
     void showVoicemailNotification(int count);
+    void playClass0SMSAlert();
     QContactManager* contactManager();
 
 


### PR DESCRIPTION
Class 0 SMS doesn't trigger a notification (the UI is expected to offer
an intrusive dialog instead), so the alert sound needs to be played
explicitly.
