### PR TITLE
[commhistory-daemon] Load translations using QTranslator instead of MLocale

### DIFF
--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -65,7 +65,7 @@ ln -s ../commhistoryd.service %{buildroot}%{_libdir}/systemd/user/user-session.t
 %{_bindir}/commhistoryd
 %{_libdir}/systemd/user/commhistoryd.service
 %{_libdir}/systemd/user/user-session.target.wants/commhistoryd.service
-%{_datadir}/translations/commhistoryd.qm
+%{_datadir}/translations/commhistoryd_eng_en.qm
 %{_datadir}/lipstick/notificationcategories/*
 %{_datadir}/telepathy/clients/CommHistory.client
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,8 +25,6 @@
 #include <sys/socket.h>
 #include <syslog.h>
 
-#include <MLocale>
-
 // Our includes
 #include "logger.h"
 #include "notificationmanager.h"
@@ -137,17 +135,13 @@ Q_DECL_EXPORT int main(int argc, char **argv)
     QObject::connect(snTerm, SIGNAL(activated(int)), &app, SLOT(quit()));
     setupSigtermHandler();
 
-    ML10N::MLocale locale;
-    locale.addTranslationPath("/usr/share/translations/");
-    locale.installTrCatalog("messaging");
-    locale.installTrCatalog("telephony");
-    locale.installTrCatalog("mms");
-    locale.installTrCatalog("presence");
-    locale.installTrCatalog("recipientedit");
-    locale.installTrCatalog("commhistoryd");
-    ML10N::MLocale::setDefault(locale);
+    QScopedPointer<QTranslator> engineeringEnglish(new QTranslator);
+    engineeringEnglish->load("commhistoryd_eng_en", "/usr/share/translations");
+    QScopedPointer<QTranslator> translator(new QTranslator);
+    translator->load(QLocale(), "commhistoryd", "-", "/usr/share/translations");
 
-    DEBUG() << "Translation catalogs loaded";
+    app.installTranslator(engineeringEnglish.data());
+    app.installTranslator(translator.data());
 
     CommHistoryService *chService = CommHistoryService::instance();
     if (!chService->isRegistered()) {

--- a/translations/translations.pro
+++ b/translations/translations.pro
@@ -47,7 +47,7 @@ QMAKE_LFLAGS = --version
 
 # translation input/output
 TS_FILENAME = $${_PRO_FILE_PWD_}/$${CATALOGNAME}.ts
-QM_FILENAME = $${_PRO_FILE_PWD_}/$${CATALOGNAME}.qm
+QM_FILENAME = $${_PRO_FILE_PWD_}/$${CATALOGNAME}_eng_en.qm
 
 # LUPDATE and LRELEASE --------------------------------------------------------
 LUPDATE_CMD = lupdate \


### PR DESCRIPTION
MLocale's expected format doesn't match our translations, which resulted
in only engineering english being loaded. This matches the rest of the
applications on the platform.
