### PR TITLE
[commhistory-daemon] Add LastDialedCache as a hack for Bluetooth

### DIFF
--- a/src/lastdialedcache.cpp
+++ b/src/lastdialedcache.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+**
+** This file is part of commhistory-daemon.
+**
+** Copyright (C) 2013 Jolla Ltd.
+** Contact: John Brooks <john.brooks@jolla.com>
+**
+** This library is free software; you can redistribute it and/or modify it
+** under the terms of the GNU Lesser General Public License version 2.1 as
+** published by the Free Software Foundation.
+**
+** This library is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+** or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+** License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with this library; if not, write to the Free Software Foundation, Inc.,
+** 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+**
+******************************************************************************/
+
+#include "lastdialedcache.h"
+#include "debug.h"
+#include <QFile>
+#include <QSaveFile>
+#include <QStandardPaths>
+
+using namespace RTComLogger;
+using namespace CommHistory;
+
+LastDialedCache::LastDialedCache(QObject *parent)
+    : QObject(parent)
+{
+    filePath = QStandardPaths::writableLocation(QStandardPaths::GenericCacheLocation) + "/last-dialed";
+
+    model = new CallModel(this);
+    connect(model, SIGNAL(modelReset()), SLOT(onModelReset()));
+    connect(model, SIGNAL(rowsInserted(QModelIndex,int,int)), SLOT(onRowsInserted(QModelIndex,int,int)));
+    connect(model, SIGNAL(rowsRemoved(QModelIndex,int,int)), SLOT(onRowsRemoved(QModelIndex,int,int)));
+
+    model->setSorting(CallModel::SortByContact);
+    model->setFilterType(CallEvent::DialedCallType);
+    model->setLimit(1);
+    model->getEvents();
+}
+
+void LastDialedCache::onRowsInserted(const QModelIndex &parent, int start, int end)
+{
+    Q_UNUSED(parent);
+    Q_UNUSED(end);
+
+    if (start == 0)
+        writeLastDialed(model->event(model->index(0, 0)).remoteUid());
+}
+
+void LastDialedCache::onRowsRemoved(const QModelIndex &parent, int start, int end)
+{
+    Q_UNUSED(parent);
+    Q_UNUSED(end);
+
+    if (model->rowCount() == 0)
+        removeLastDialed();
+    else if (start == 0)
+        writeLastDialed(model->event(model->index(0, 0)).remoteUid());
+}
+
+void LastDialedCache::onModelReset()
+{
+    if (model->rowCount() == 0)
+        removeLastDialed();
+    else
+        writeLastDialed(model->event(model->index(0, 0)).remoteUid());
+}
+
+void LastDialedCache::writeLastDialed(const QString &number)
+{
+    QSaveFile file(filePath);
+    if (!file.open(QIODevice::WriteOnly | QIODevice::Truncate)) {
+        qWarning() << "Cannot open last dialed cache file:" << file.errorString();
+        return;
+    }
+
+    DEBUG() << "Writing last dialed number to file:" << number;
+    file.write(number.toLatin1());
+    if (!file.commit())
+        qWarning() << "Writing last dialed cache failed:" << file.errorString();
+}
+
+void LastDialedCache::removeLastDialed()
+{
+    DEBUG() << "Removing last dialed number file";
+    QFile::remove(filePath);
+}
+

--- a/src/lastdialedcache.h
+++ b/src/lastdialedcache.h
@@ -1,0 +1,59 @@
+/******************************************************************************
+**
+** This file is part of commhistory-daemon.
+**
+** Copyright (C) 2013 Jolla Ltd.
+** Contact: John Brooks <john.brooks@jolla.com>
+**
+** This library is free software; you can redistribute it and/or modify it
+** under the terms of the GNU Lesser General Public License version 2.1 as
+** published by the Free Software Foundation.
+**
+** This library is distributed in the hope that it will be useful, but
+** WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+** or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+** License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public License
+** along with this library; if not, write to the Free Software Foundation, Inc.,
+** 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+**
+******************************************************************************/
+
+#ifndef LASTDIALEDCACHE_H
+#define LASTDIALEDCACHE_H
+
+#include <QObject>
+#include <CommHistory/CallModel>
+
+namespace RTComLogger {
+
+/* Write the last dialed number from the call log to a cache file,
+ * and update the number when items are removed from the call log.
+ *
+ * This is a hack to provide functionality necessary for bluez,
+ * which is otherwise unable to access commhistory data in any sane way.
+ */
+class LastDialedCache : public QObject
+{
+    Q_OBJECT
+
+public:
+    LastDialedCache(QObject *parent);
+
+private slots:
+    void onRowsInserted(const QModelIndex &parent, int start, int end);
+    void onRowsRemoved(const QModelIndex &parent, int start, int end);
+    void onModelReset();
+
+private:
+    QString filePath;
+    CommHistory::CallModel *model;
+
+    void writeLastDialed(const QString &number);
+    void removeLastDialed();
+};
+
+}
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,6 +35,7 @@
 #include "messagereviver.h"
 #include "contactauthorizationlistener.h"
 #include "connectionutils.h"
+#include "lastdialedcache.h"
 #include "accountoperationsobserver.h"
 #include "debug.h"
 
@@ -173,6 +174,8 @@ Q_DECL_EXPORT int main(int argc, char **argv)
     NotificationManager::instance();
     DEBUG() << "NotificationManager created";
 
+    new LastDialedCache(&app);
+    DEBUG() << "LastDialedCache created";
 
     // Init account operations observer to monitor account removals and to react to them.
     new AccountOperationsObserver(utils->accountManager(), &app);

--- a/src/src.pro
+++ b/src/src.pro
@@ -71,6 +71,7 @@ HEADERS += logger.h \
            accountoperationsobserver.h \
            accountpresenceifadaptor.h \
            accountpresenceservice.h \
+           lastdialedcache.h \
            debug.h
 
 SOURCES += main.cpp \
@@ -92,7 +93,8 @@ SOURCES += main.cpp \
            mwilistener.cpp \
            accountoperationsobserver.cpp \
            accountpresenceifadaptor.cpp \
-           accountpresenceservice.cpp
+           accountpresenceservice.cpp \
+           lastdialedcache.cpp
 
 # -----------------------------------------------------------------------------
 # Telepathy extensions.


### PR DESCRIPTION
Bluetooth requires the last dialed number from the call log, but for
various reasons can't access commhistory or dbus directly. As a hack,
write the last dialed number from the call log into a file at
$HOME/.cache/last-dialed and keep it updated even when items are removed
from the call log, or the log is cleared.

Sigh.
