### PR TITLE
[commhistory-daemon] Use SortByTime for LastDialedCache

### DIFF
--- a/src/lastdialedcache.cpp
+++ b/src/lastdialedcache.cpp
@@ -39,7 +39,8 @@ LastDialedCache::LastDialedCache(QObject *parent)
     connect(model, SIGNAL(rowsInserted(QModelIndex,int,int)), SLOT(onRowsInserted(QModelIndex,int,int)));
     connect(model, SIGNAL(rowsRemoved(QModelIndex,int,int)), SLOT(onRowsRemoved(QModelIndex,int,int)));
 
-    model->setSorting(CallModel::SortByContact);
+    model->setTreeMode(false);
+    model->setSorting(CallModel::SortByTime);
     model->setFilterType(CallEvent::DialedCallType);
     model->setLimit(1);
     model->getEvents();


### PR DESCRIPTION
SortByContact was previously necessary because of bugs in the ungrouped
model, but libcommhistory has been updated to solve that. SortByTime
properly filters and avoids cases where incoming calls wouldn't be
filtered by the model.
