### PR TITLE
[commhistory-daemon] Trim surrounding whitespace from incoming messages

### DIFF
--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -995,7 +995,7 @@ bool TextChannelListener::recoverDeliveryEcho(const Tp::Message &message,
             QString content = parts[1].value(PART_CONTENT).variant().toString();
 
             if (contentType == TXT_CONTENT_TYPE) {
-                event.setFreeText(content);
+                event.setFreeText(content.trimmed());
                 result = true;
             } else if (contentType == VCARD_CONTENT_TYPE) {
                 checkVCard(parts, event);
@@ -1425,7 +1425,7 @@ void TextChannelListener::fillEventFromMessage(const Tp::Message &message,
     }
 
     event.setLocalUid(m_Account->objectPath());
-    event.setFreeText(message.text());
+    event.setFreeText(message.text().trimmed());
 
     // do not set / create group id for class0 messages
     if (!m_isClassZeroSMS) {


### PR DESCRIPTION
There isn't much point in keeping surrounding whitespace on messages, and it looks bad in display. It can also occur fairly often for IM messages from people using OTR's signalling feature.
