### PR TITLE
[commhistory-daemon] Temporarily disable contact authorization notifications

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -153,7 +153,8 @@ Q_DECL_EXPORT int main(int argc, char **argv)
 
     ConnectionUtils *utils = new ConnectionUtils(&app);
 
-    new ContactAuthorizationListener(utils, chService);
+    // ContactAuthorizationListener needs to be updated with nemo-notifications and new UI handling
+    //new ContactAuthorizationListener(utils, chService);
 
     AccountPresenceService *apService = new AccountPresenceService(utils->accountManager(), &app);
     if (!apService->isRegistered()) {


### PR DESCRIPTION
The contact authorization code needs to be modernized, ported to nemo-notifications, and proper UI handling implemented. Disable it entirely until these can be done.

This removes the currently action-less and impossible to permanently remove contact authorization notifications.
