### PR TITLE
[commhistory-daemon] Remove error state for messages sent to offline contacts

### DIFF
--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -1536,11 +1536,6 @@ void TextChannelListener::slotMessageSent(const Tp::Message &message,
         event.setReportDelivery(true);
     }
 
-    if (event.type() == CommHistory::Event::IMEvent
-        && areRemotePartiesOffline()) {
-        event.setStatus(CommHistory::Event::TemporarilyFailedOfflineStatus);
-    }
-
     QStringList recipients;
     recipients <<  event.toList() << event.ccList() << event.bccList();
     if (recipients.isEmpty()) {


### PR DESCRIPTION
For most supported services, offline messaging is possible and the
message will be sent when the remote user connects. It's inappropriate
to mark those messages as failed.

For services that don't do offline messaging, they should return an
error, which will separately set the status to failed.

A banner is displayed the first time you send a message to an offline
contact, reminding you that they are offline. This is not very clear and
should be improved as well.
