### PR TITLE
[commhistory-daemon] Fix ut_messagereviver

### DIFF
--- a/tests/ut_messagereviver/ut_messagereviver.cpp
+++ b/tests/ut_messagereviver/ut_messagereviver.cpp
@@ -133,7 +133,7 @@ void Ut_MessageReviver::revive()
     QVERIFY(sm->ut_getDeliveredMessages().isEmpty());
 
     QMetaObject::invokeMethod(&reviver,
-                              "onConnectionReady",
+                              "checkConnection",
                               Qt::DirectConnection,
                               Q_ARG(Tp::ConnectionPtr, conn));
 


### PR DESCRIPTION
Broken since 79e0ea7 (Try to redeliver message if it was not saved).

To see its effect, this must be accepted first: nemomobile/libcommhistory#55
