### PR TITLE
[commhistoryd] Start after lipstick for notifications API

### DIFF
--- a/data/commhistoryd.service
+++ b/data/commhistoryd.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Communication history daemon
-After=pre-user-session.target booster-qt5.service
+# lipstick.service needed for org.freedesktop.Notifications
+After=pre-user-session.target booster-qt5.service lipstick.service
 Requires=dbus.socket booster-qt5.service
 
 [Service]


### PR DESCRIPTION
This fixes duplicate notifications after a reboot, which happened
because commhistoryd tried to read the existing notifications before
lipstick's notification API was available.
