### PR TITLE
[commhistory-daemon] Always mark outgoing MMS message events as seen

### DIFF
--- a/src/mmshandler.cpp
+++ b/src/mmshandler.cpp
@@ -477,6 +477,7 @@ int MmsHandler::sendMessage(const QStringList &to, const QStringList &cc, const 
     event.setLocalUid(RING_ACCOUNT_PATH);
     event.setSubject(subject);
     event.setStatus(Event::SendingStatus);
+    event.setIsRead(true);
 
     event.setRemoteUid(CommHistory::normalizePhoneNumber(to[0])); // XXX Wrong for group conversations!
     event.setToList(normalizeNumberList(to));


### PR DESCRIPTION
The isRead property refers to whether the user has seen an event, for
inbound events. An outgoing event shouldn't be considered unread.

There is a different property for remote read state when read receipts
are enabled.
