### PR TITLE
Delete attachments from the filesystem

### DIFF
--- a/common-project-config.pri
+++ b/common-project-config.pri
@@ -34,4 +34,4 @@ UI_SOURCES_DIR  = ui/src
 QT             -= thread
 
 # we don't like warnings...
-QMAKE_CXXFLAGS *= -Werror -Wall -fno-exceptions
+QMAKE_CXXFLAGS *= -Werror -Wno-unused-parameter -Wall -fno-exceptions

--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -11,7 +11,7 @@ BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Contacts)
 BuildRequires:  pkgconfig(Qt5Versit)
 BuildRequires:  pkgconfig(Qt5Test)
-BuildRequires:  libcommhistory-qt5-devel >= 1.7.20
+BuildRequires:  libcommhistory-qt5-devel >= 1.8.1
 BuildRequires:  pkgconfig(TelepathyQt5)
 BuildRequires:  pkgconfig(mlite5)
 BuildRequires:  pkgconfig(mlocale5)
@@ -24,6 +24,7 @@ BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist
 BuildRequires:  libqofono-qt5-devel
 BuildRequires:  python
+Requires:  libcommhistory-qt5 >= 1.8.1
 Requires:  libqofono-qt5 >= 0.66
 Requires:  mapplauncherd-qt5
 Requires:  mms-engine

--- a/src/fscleanup.cpp
+++ b/src/fscleanup.cpp
@@ -1,0 +1,112 @@
+/****************************************************************************
+**
+** This file is part of commhistory-daemon.
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Slava Monich <slava.monich@jolla.com>
+**
+** This library is free software; you can redistribute it and/or modify
+** it under the terms of the GNU Lesser General Public License version 2.1
+** as published by the Free Software Foundation.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public
+** License along with this library; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+**
+****************************************************************************/
+
+#include "fscleanup.h"
+#include "debug.h"
+
+#include <CommHistory/commhistorydatabasepath.h>
+#include <CommHistory/databaseio.h>
+#include <CommHistory/constants.h>
+
+#include <QDirIterator>
+#include <QDBusConnection>
+
+#ifdef DEBUG_COMMHISTORY
+#  define DEBUG_(x) qDebug() << "FsCleanup:" << x
+#else
+#  define DEBUG_(x) ((void)0)
+#endif
+
+FsCleanup::FsCleanup(QObject* aParent) :
+    QObject(aParent)
+{
+    QDBusConnection dbus(QDBusConnection::sessionBus());
+    dbus.connect(QString(), QString(), COMM_HISTORY_INTERFACE,
+        EVENT_DELETED_SIGNAL, this, SLOT(onEventDeleted(int)));
+    dbus.connect(QString(), QString(), COMM_HISTORY_INTERFACE,
+        GROUPS_DELETED_SIGNAL, this, SLOT(onGroupsDeleted(QList<int>)));
+    fullCleanup();
+}
+
+void FsCleanup::onEventDeleted(int aEventId)
+{
+    DEBUG_("Event" << aEventId << "deleted");
+    deleteFiles(aEventId);
+}
+
+void FsCleanup::onGroupsDeleted(QList<int> aGroupIds)
+{
+    DEBUG_(aGroupIds.count() << "group(s) deleted");
+    fullCleanup();
+}
+
+void FsCleanup::fullCleanup()
+{
+    DEBUG_("Running full cleanup");
+    CommHistory::DatabaseIO* io = CommHistory::DatabaseIO::instance();
+    QDirIterator it(CommHistoryDatabasePath::dataDir(),
+        QDir::Dirs | QDir::NoDotAndDotDot);
+    while (it.hasNext()) {
+        it.next();
+        bool ok = false;
+        int id = it.fileName().toInt(&ok);
+        if (ok && !io->eventExists(id)) {
+            deleteFiles(id);
+        }
+    }
+    DEBUG_("Cleanup done");
+}
+
+void FsCleanup::deleteFiles(int aEventId)
+{
+    removeDir(CommHistoryDatabasePath::dataDir(aEventId));
+}
+
+bool FsCleanup::removeDir(QString aDirPath)
+{
+    bool result = true;
+    QDir dir(aDirPath);
+    if (dir.exists()) {
+        DEBUG_("Removing" << aDirPath);
+        QFileInfoList list = dir.entryInfoList(QDir::NoDotAndDotDot |
+            QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files,
+            QDir::DirsFirst);
+        for (int i=0; i<list.count(); i++) {
+            QFileInfo info(list.at(i));
+            QString path(info.absoluteFilePath());
+            if (info.isDir()) {
+                result = removeDir(path);
+            } else {
+                result = QFile::remove(path);
+            }
+            if (!result) {
+                qWarning() << "Failed to remove" << path;
+                return result;
+            }
+        }
+        result = dir.rmdir(aDirPath);
+        if (!result) {
+            qWarning() << "Failed to remove" << aDirPath;
+        }
+    }
+    return result;
+}

--- a/src/fscleanup.h
+++ b/src/fscleanup.h
@@ -1,0 +1,47 @@
+/****************************************************************************
+**
+** This file is part of commhistory-daemon.
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Slava Monich <slava.monich@jolla.com>
+**
+** This library is free software; you can redistribute it and/or modify
+** it under the terms of the GNU Lesser General Public License version 2.1
+** as published by the Free Software Foundation.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+** You should have received a copy of the GNU Lesser General Public
+** License along with this library; if not, write to the Free Software
+** Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+**
+****************************************************************************/
+
+#ifndef FSCLEANUP_H
+#define FSCLEANUP_H
+
+#include <QObject>
+#include <QString>
+#include <QList>
+
+class FsCleanup: public QObject
+{
+    Q_OBJECT
+
+public:
+    FsCleanup(QObject* aParent);
+
+private Q_SLOTS:
+    void onEventDeleted(int aEventId);
+    void onGroupsDeleted(QList<int> aGroupIds);
+
+private:
+    static void fullCleanup();
+    static void deleteFiles(int aEventId);
+    static bool removeDir(QString aDirPath);
+};
+
+#endif // FSCLEANUP_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "connectionutils.h"
 #include "lastdialedcache.h"
 #include "accountoperationsobserver.h"
+#include "fscleanup.h"
 #include "mmshandler.h"
 #include "mmshandler_adaptor.h"
 #include "smartmessaging_adaptor.h"
@@ -185,10 +186,9 @@ Q_DECL_EXPORT int main(int argc, char **argv)
     // Init account operations observer to monitor account removals and to react to them.
     new AccountOperationsObserver(utils->accountManager(), &app);
 
-    MmsHandler *mmsHandler = new MmsHandler(&app);
-    new MmsHandlerAdaptor(mmsHandler);
-
+    new MmsHandlerAdaptor(new MmsHandler(&app));
     new SmartMessagingAgentAdaptor(new SmartMessaging(&app));
+    new FsCleanup(&app);
 
     int result = app.exec();
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -75,6 +75,7 @@ HEADERS += logger.h \
            accountpresenceservice.h \
            lastdialedcache.h \
            debug.h \
+           fscleanup.h \
            mmshandler.h \
            mmspart.h \
            messagehandlerbase.h \
@@ -100,6 +101,7 @@ SOURCES += main.cpp \
            accountpresenceifadaptor.cpp \
            accountpresenceservice.cpp \
            lastdialedcache.cpp \
+           fscleanup.cpp \
            mmshandler.cpp \
            messagehandlerbase.cpp \
            smartmessaging.cpp


### PR DESCRIPTION
When events with attachments are removed from the commhistory database, associated files (such as MMS attachments and vcards received as SMS) need to be deleted from the filesystem.

Requires https://github.com/nemomobile/libcommhistory/pull/102
