### PR TITLE
[commhistory-daemon] Group notifications by correct property

### DIFF
--- a/data/notifications/x-nemo.call.missed.conf
+++ b/data/notifications/x-nemo.call.missed.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-missed-call
 x-nemo-preview-icon=icon-s-status-call-missed
 x-nemo-feedback=call

--- a/data/notifications/x-nemo.messaging.authorizationrequest.conf
+++ b/data/notifications/x-nemo.messaging.authorizationrequest.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-invitation
 x-nemo-preview-icon=icon-s-status-invitation-pending
 x-nemo-feedback=default

--- a/data/notifications/x-nemo.messaging.error.conf
+++ b/data/notifications/x-nemo.messaging.error.conf
@@ -1,2 +1,3 @@
+appIcon=icon-lock-chat
 urgency=2
 transient=true

--- a/data/notifications/x-nemo.messaging.error.strong.conf
+++ b/data/notifications/x-nemo.messaging.error.strong.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 urgency=2
 transient=true
 x-nemo-feedback=warning_strong

--- a/data/notifications/x-nemo.messaging.im.conf
+++ b/data/notifications/x-nemo.messaging.im.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-chat
 x-nemo-preview-icon=icon-s-status-chat
 x-nemo-feedback=chat

--- a/data/notifications/x-nemo.messaging.mms.conf
+++ b/data/notifications/x-nemo.messaging.mms.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-mms
 x-nemo-preview-icon=icon-s-status-mms
 x-nemo-feedback=sms

--- a/data/notifications/x-nemo.messaging.sms.conf
+++ b/data/notifications/x-nemo.messaging.sms.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-sms
 x-nemo-preview-icon=icon-s-status-sms
 x-nemo-feedback=sms

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-voicemail
 x-nemo-preview-icon=icon-s-status-voicemail
 x-nemo-priority=100

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -1,3 +1,4 @@
+appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-voicemail
 x-nemo-preview-icon=icon-s-status-voicemail
 x-nemo-user-removable=false

--- a/rpm/commhistory-daemon.spec
+++ b/rpm/commhistory-daemon.spec
@@ -18,7 +18,7 @@ BuildRequires:  pkgconfig(mlocale5)
 BuildRequires:  pkgconfig(mce)
 BuildRequires:  pkgconfig(ngf-qt5)
 BuildRequires:  pkgconfig(qt5-boostable)
-BuildRequires:  pkgconfig(nemonotifications-qt5) >= 1.0.4
+BuildRequires:  pkgconfig(nemonotifications-qt5) >= 1.0.5
 BuildRequires:  pkgconfig(contextkit-statefs)
 BuildRequires:  qt5-qttools
 BuildRequires:  qt5-qttools-linguist

--- a/src/constants.h
+++ b/src/constants.h
@@ -108,10 +108,10 @@ static const EventTypes _eventTypes[] =
 };
 
 static const int _eventTypesCount = sizeof(_eventTypes) / sizeof(EventTypes);
-}
 
 // Custom system info notification types for commhistoryd:
 const QString ErrorCategory = "x-nemo.messaging.error";
 const QString StrongErrorCategory = "x-nemo.messaging.error.strong";
+}
 
 #endif //#define CONSTANTS_H

--- a/src/contactauthorizationlistener.cpp
+++ b/src/contactauthorizationlistener.cpp
@@ -247,7 +247,10 @@ void ContactAuthorizationListener::slotShowUnableToAuthorizeDialog(const QString
     }
 
     if (showNotification) {
+        // TODO: No category for this notification?
         Notification notification;
+        notification.setAppName(txt_qtn_msg_notifications_group);
+        notification.setAppIcon("icon-lock-chat");
         notification.setBody(txt_qtn_pers_offline);
         if (!accountPath.isEmpty()) {
             notification.setHintValue(ACCOUNT_PATH_HINT, accountPath);

--- a/src/contactauthorizer.cpp
+++ b/src/contactauthorizer.cpp
@@ -431,6 +431,7 @@ void ContactAuthorizer::fireAuthorisationRequest()
         request.notificationId = id + "|" + m_account->objectPath();
 
         Notification notification;
+        notification.setAppName(txt_qtn_msg_notifications_group);
         notification.setCategory(AuthorizationNotificationType);
         notification.setSummary(request.contact->alias().isEmpty() ? request.contact->id() : request.contact->alias());
         notification.setBody(txt_qtn_pers_authorization_req);

--- a/src/locstrings.h
+++ b/src/locstrings.h
@@ -46,6 +46,11 @@
 
 #include <MLocale>
 
+//% "Messages"
+#define txt_qtn_msg_notifications_group qtTrId("qtn_msg_notifications_group")
+//% "Warnings"
+#define txt_qtn_msg_errors_group qtTrId("qtn_msg_errors_group")
+
 //% "%n new message(s)"
 #define txt_qtn_msg_notification_new_message(NUM) qtTrId("qtn_msg_notification_new_message", NUM)
 //% "Contact card"

--- a/src/notificationgroup.cpp
+++ b/src/notificationgroup.cpp
@@ -110,6 +110,7 @@ void NotificationGroup::updateGroup()
         mGroup = new Notification(this);
 
     // Disable feedback from the notification definition; it's played by individual banners
+    mGroup->setAppName(txt_qtn_msg_notifications_group);
     mGroup->setHintValue("x-nemo-feedback", QString());
     mGroup->setCategory(groupType(type()));
     mGroup->setBody(notificationGroupText());

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -25,6 +25,7 @@
 #include "notificationmanager.h"
 #include "notificationgroup.h"
 #include "locstrings.h"
+#include "constants.h"
 #include "debug.h"
 #include <CommHistory/commonutils.h>
 #include <notification.h>
@@ -109,6 +110,7 @@ void PersonalNotification::publishNotification()
     if (!m_notification)
         m_notification = new Notification(this);
 
+    m_notification->setAppName(txt_qtn_msg_notifications_group);
     m_notification->setCategory(NotificationGroup::groupType(m_eventType));
     m_notification->setHintValue("x-commhistoryd-data", serialized().toBase64());
     NotificationManager::instance()->setNotificationAction(m_notification, this, false);

--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -1200,6 +1200,7 @@ void TextChannelListener::showErrorNote(const QString &errorMsg, const QString &
 {
     if (!errorMsg.isEmpty()) {
         Notification notification;
+        notification.setAppName(txt_qtn_msg_errors_group);
         notification.setCategory(category);
         notification.setBody(category);
         notification.setPreviewBody(category);


### PR DESCRIPTION
Do not use the group name to identify notifications owned by this process.  Also set the app name for display purposes.