### PR TITLE
[commhistory-daemon] Group notifications by type and endpoints

### DIFF
--- a/data/notifications/x-nemo.messaging.group.conf
+++ b/data/notifications/x-nemo.messaging.group.conf
@@ -1,0 +1,6 @@
+appIcon=icon-lock-chat
+x-nemo-icon=icon-lock-chat
+x-nemo-preview-icon=icon-s-status-chat
+x-nemo-feedback=chat
+x-nemo-priority=100
+x-nemo-led-disabled-without-body-and-summary=false

--- a/src/notificationgroup.h
+++ b/src/notificationgroup.h
@@ -24,6 +24,8 @@
 #ifndef NOTIFICATIONGROUP_H
 #define NOTIFICATIONGROUP_H
 
+#include "personalnotification.h"
+
 #include <QObject>
 #include <QString>
 #include <QMetaType>
@@ -37,21 +39,21 @@ namespace CommHistory {
 
 namespace RTComLogger {
 
-class PersonalNotification;
-
 class NotificationGroup : public QObject
 {
     Q_OBJECT
 
 public:
-    explicit NotificationGroup(int type, QObject *parent = 0);
-    explicit NotificationGroup(Notification *mGroup, QObject* parent = 0);
+    NotificationGroup(PersonalNotification::EventCollection collection, const QString &localUid, const QString &remoteUid, QObject *parent = 0);
     virtual ~NotificationGroup();
 
     static QString groupType(int eventType);
     static int eventType(const QString &groupType);
 
-    int type() const;
+    PersonalNotification::EventCollection collection() const;
+    const QString &localUid() const;
+    const QString &remoteUid() const;
+
     Notification *notification();
     QList<PersonalNotification*> notifications() const;
 
@@ -87,7 +89,9 @@ private slots:
     void onNotificationChanged();
 
 private:
-    int m_type;
+    PersonalNotification::EventCollection m_collection;
+    QString m_localUid;
+    QString m_remoteUid;
     Notification *mGroup;
     QList<PersonalNotification*> mNotifications;
     QTimer updateTimer;

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -99,8 +99,7 @@ void NotificationManager::init()
     connect(service, SIGNAL(observedConversationsChanged(QVariantList)),
                      SLOT(slotObservedConversationsChanged(QVariantList)));
 
-    if (hasMessageNotification())
-        groupModel();
+    groupModel();
 
     m_Initialised = true;
 }
@@ -114,15 +113,10 @@ void NotificationManager::syncNotifications()
     foreach (QObject *o, notifications) {
         Notification *n = static_cast<Notification*>(o);
 
-        if (n->previewBody().isEmpty() && !n->body().isEmpty() && n->hintValue("x-commhistoryd-data").isNull()) {
-            NotificationGroup *group = new NotificationGroup(n, this);
-            if (m_Groups.contains(group->type())) {
-                group->removeGroup();
-                delete group;
-                continue;
-            }
-
-            m_Groups.insert(group->type(), group);
+        if (n->hintValue("x-commhistoryd-data").isNull()) {
+            // This was a group notification, which will be recreated if required
+            n->close();
+            delete n;
         } else {
             PersonalNotification *pn = new PersonalNotification(this);
             if (!pn->restore(n)) {
@@ -139,17 +133,6 @@ void NotificationManager::syncNotifications()
 
     foreach (PersonalNotification *pn, pnList)
         resolveNotification(pn);
-
-    // Remove groups with no events or unresolved events
-    for (QMap<int,NotificationGroup*>::iterator it = m_Groups.begin(); it != m_Groups.end(); ) {
-        NotificationGroup *group = *it;
-        if (typeCounts[group->type()] < 1) {
-            group->removeGroup();
-            delete group;
-            it = m_Groups.erase(it);
-        } else
-            it++;
-    }
 }
 
 NotificationManager* NotificationManager::instance()
@@ -174,7 +157,8 @@ bool NotificationManager::updateEditedEvent(const CommHistory::Event& event)
         }
     }
 
-    NotificationGroup *eventGroup = m_Groups.value(event.type());
+    EventGroupProperties groupProperties(eventGroup(PersonalNotification::collection(event.type()), event.localUid(), event.remoteUid()));
+    NotificationGroup *eventGroup = m_Groups.value(groupProperties);
     if (!eventGroup)
         return false;
 
@@ -336,7 +320,7 @@ bool NotificationManager::isCurrentlyObservedByUI(const CommHistory::Event& even
     return false;
 }
 
-void NotificationManager::removeNotifications(const QString &accountPath, bool messagesOnly)
+void NotificationManager::removeNotifications(const QString &accountPath, const QList<int> &removeTypes)
 {
     DEBUG() << Q_FUNC_INFO << "Removing notifications of account " << accountPath;
 
@@ -344,19 +328,12 @@ void NotificationManager::removeNotifications(const QString &accountPath, bool m
 
     // remove matched notifications and update group
     foreach (NotificationGroup *group, m_Groups) {
-        int eventType = group->type();
-
-        // If removal should be done based on Inbox being observed then remove only those notifications
-        // that belong to messaging-ui area:
-        if (messagesOnly && (eventType != CommHistory::Event::IMEvent && eventType != CommHistory::Event::SMSEvent
-             && eventType != CommHistory::Event::MMSEvent && eventType != VOICEMAIL_SMS_EVENT_TYPE)) {
-            DEBUG() << Q_FUNC_INFO << "Skipping " << eventType << " type of notification";
+        if (group->localUid() != accountPath) {
             continue;
         }
 
         foreach (PersonalNotification *notification, group->notifications()) {
-            // Remove only a notification matching to the account:
-            if (notification->account() == accountPath) {
+            if (removeTypes.isEmpty() || removeTypes.contains(notification->eventType())) {
                 DEBUG() << Q_FUNC_INFO << "Removing notification: accountPath: " << notification->account() << " remoteUid: " << notification->remoteUid();
                 group->removeNotification(notification);
             }
@@ -377,15 +354,16 @@ void NotificationManager::removeConversationNotifications(const QString &localUi
                                                           const QString &remoteUid,
                                                           CommHistory::Group::ChatType chatType)
 {
-    foreach (NotificationGroup *group, m_Groups) {
-        int eventType = group->type();
-        if (eventType != CommHistory::Event::IMEvent
-             && eventType != CommHistory::Event::SMSEvent
-             && eventType != CommHistory::Event::MMSEvent
-             && eventType != VOICEMAIL_SMS_EVENT_TYPE)
+    QHash<EventGroupProperties, NotificationGroup *>::const_iterator it = m_Groups.constBegin(), end = m_Groups.constEnd();
+    for ( ; it != end; ++it) {
+        NotificationGroup *group(it.value());
+        if (group->localUid() != localUid)
             continue;
 
         foreach (PersonalNotification *notification, group->notifications()) {
+            if (notification->collection() != PersonalNotification::Messaging)
+                continue;
+
             QString notificationRemoteUidStr;
             // For p-to-p chat we use remote uid for comparison and for MUC we use target (channel) id:
             if (chatType == CommHistory::Group::ChatTypeP2P)
@@ -421,19 +399,18 @@ void NotificationManager::slotInboxObservedChanged()
     // Cannot be passed as a parameter, because this slot is also used for m_notificationTimer
     bool observed = CommHistoryService::instance()->inboxObserved();
     if (observed) {
+        QList<int> removeTypes;
+        removeTypes << CommHistory::Event::IMEvent << CommHistory::Event::SMSEvent << CommHistory::Event::MMSEvent << VOICEMAIL_SMS_EVENT_TYPE;
+
         if (!isFilteredInbox()) {
-            // remove sms, mms and im notification groups
-            // remove meegotouch groups
-            removeNotificationGroup(CommHistory::Event::IMEvent);
-            removeNotificationGroup(CommHistory::Event::SMSEvent);
-            removeNotificationGroup(CommHistory::Event::MMSEvent);
-            removeNotificationGroup(VOICEMAIL_SMS_EVENT_TYPE);
+            // remove sms, mms and im notifications
+            removeNotificationTypes(removeTypes);
         } else {
             // Filtering is in use, remove only notifications of that account whose threads are visible in inbox:
             QString filteredAccountPath = filteredInboxAccountPath();
             DEBUG() << Q_FUNC_INFO << "Removing only notifications belonging to account " << filteredAccountPath;
             if (!filteredAccountPath.isEmpty())
-                removeNotifications(filteredAccountPath, true);
+                removeNotifications(filteredAccountPath, removeTypes);
         }
     }
 }
@@ -441,7 +418,7 @@ void NotificationManager::slotInboxObservedChanged()
 void NotificationManager::slotCallHistoryObservedChanged(bool observed)
 {
     if (observed) {
-        removeNotificationGroup(CommHistory::Event::CallEvent);
+        removeNotificationTypes(QList<int>() << CommHistory::Event::CallEvent);
     }
 }
 
@@ -455,29 +432,26 @@ QString NotificationManager::filteredInboxAccountPath()
     return CommHistoryService::instance()->inboxFilterAccount();
 }
 
-bool NotificationManager::removeNotificationGroup(int type)
+void NotificationManager::removeNotificationTypes(const QList<int> &types)
 {
-    DEBUG() << Q_FUNC_INFO << type;
+    DEBUG() << Q_FUNC_INFO << types;
 
-    QMap<int,NotificationGroup*>::iterator it = m_Groups.find(type);
-    if (it == m_Groups.end())
-        return false;
-
-    (*it)->removeGroup();
-    delete *it;
-    m_Groups.erase(it);
-
-    return true;
+    foreach (NotificationGroup *group, m_Groups) {
+        foreach (PersonalNotification *notification, group->notifications()) {
+            if (types.contains(notification->eventType())) {
+                group->removeNotification(notification);
+            }
+        }
+    }
 }
 
 void NotificationManager::addNotification(PersonalNotification *notification)
 {
-    uint eventType = notification->eventType();
-
-    NotificationGroup *group = m_Groups.value(eventType);
+    EventGroupProperties groupProperties(eventGroup(notification->collection(), notification->account(), notification->remoteUid()));
+    NotificationGroup *group = m_Groups.value(groupProperties);
     if (!group) {
-        group = new NotificationGroup(eventType, this);
-        m_Groups.insert(eventType, group);
+        group = new NotificationGroup(groupProperties.collection, groupProperties.localUid, groupProperties.remoteUid, this);
+        m_Groups.insert(groupProperties, group);
     }
 
     group->addNotification(notification);
@@ -572,11 +546,8 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
     QString appName;
     QVariantList remoteActions;
 
-    switch (pn->eventType()) {
-        case CommHistory::Event::IMEvent:
-        case CommHistory::Event::SMSEvent:
-        case CommHistory::Event::MMSEvent:
-        case VOICEMAIL_SMS_EVENT_TYPE:
+    switch (pn->collection()) {
+        case PersonalNotification::Messaging:
 
             appName = txt_qtn_msg_notifications_group;
 
@@ -604,7 +575,7 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
                                             SHOW_INBOX_METHOD));
             break;
 
-        case CommHistory::Event::CallEvent:
+        case PersonalNotification::Voice:
 
             appName = txt_qtn_msg_missed_calls_group;
 
@@ -622,7 +593,7 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
                                             QVariantList() << CALL_HISTORY_PARAMETER));
             break;
 
-        case CommHistory::Event::VoicemailEvent:
+        case PersonalNotification::Voicemail:
 
             appName = txt_qtn_msg_voicemail_group;
 
@@ -754,13 +725,6 @@ void NotificationManager::showVoicemailNotification(int count)
     qWarning() << Q_FUNC_INFO << "Stub";
 }
 
-bool NotificationManager::hasMessageNotification() const
-{
-    return m_Groups.contains(CommHistory::Event::IMEvent) ||
-           m_Groups.contains(CommHistory::Event::SMSEvent) ||
-           m_Groups.contains(CommHistory::Event::MMSEvent);
-}
-
 void NotificationManager::slotGroupDataChanged(const QModelIndex &topLeft, const QModelIndex &bottomRight)
 {
     DEBUG() << Q_FUNC_INFO;
@@ -772,10 +736,14 @@ void NotificationManager::slotGroupDataChanged(const QModelIndex &topLeft, const
         QModelIndex row = m_GroupModel->index(i, 0);
         CommHistory::Group group = m_GroupModel->group(row);
         if (group.isValid()) {
-            QString remoteUid = group.remoteUids().first();
-            QString localUid = group.localUid();
+            const QString remoteUid = group.remoteUids().first();
+            const QString localUid = group.localUid();
 
             foreach (NotificationGroup *g, m_Groups) {
+                if (g->localUid() != localUid) {
+                    continue;
+                }
+
                 foreach (PersonalNotification *pn, g->notifications()) {
                     // If notification is for MUC and matches to changed group...
                     if (!pn->chatName().isEmpty() && pn->account() == localUid &&

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -38,6 +38,7 @@ PersonalNotification::PersonalNotification(QObject* parent) : QObject(parent),
     m_chatType(CommHistory::Group::ChatTypeP2P),
     m_contactId(0),
     m_hasPendingEvents(false),
+    m_hidden(false),
     m_notification(0)
 {
 }
@@ -54,6 +55,7 @@ PersonalNotification::PersonalNotification(const QString& remoteUid,
     m_eventType(eventType), m_targetId(channelTargetId), m_chatType(chatType),
     m_contactId(contactId), m_notificationText(lastNotification),
     m_hasPendingEvents(true),
+    m_hidden(false),
     m_notification(0)
 {
 }
@@ -113,6 +115,7 @@ void PersonalNotification::publishNotification()
     m_notification->setAppName(txt_qtn_msg_notifications_group);
     m_notification->setCategory(NotificationGroup::groupType(m_eventType));
     m_notification->setHintValue("x-commhistoryd-data", serialized().toBase64());
+    m_notification->setHintValue("x-nemo-hidden", m_hidden);
     NotificationManager::instance()->setNotificationProperties(m_notification, this, false);
 
     // No preview banner for existing notifications
@@ -123,6 +126,9 @@ void PersonalNotification::publishNotification()
         m_notification->setPreviewSummary(name);
         m_notification->setPreviewBody(notificationText());
     }
+
+    m_notification->setSummary(name);
+    m_notification->setBody(notificationText());
 
     m_notification->publish();
 
@@ -155,6 +161,20 @@ QString PersonalNotification::notificationName() const
         return locale.toLocalizedNumbers(remoteUid());
     } else
         return remoteUid();
+}
+
+PersonalNotification::EventCollection PersonalNotification::collection() const
+{
+    return collection(m_eventType);
+}
+
+PersonalNotification::EventCollection PersonalNotification::collection(uint eventType)
+{
+    if (eventType == CommHistory::Event::VoicemailEvent)
+        return Voicemail;
+    if (eventType == CommHistory::Event::CallEvent)
+        return Voice;
+    return Messaging;
 }
 
 QString PersonalNotification::remoteUid() const
@@ -216,6 +236,11 @@ QString PersonalNotification::eventToken() const
 QString PersonalNotification::smsReplaceNumber() const
 {
     return m_smsReplaceNumber;
+}
+
+bool PersonalNotification::hidden() const
+{
+    return m_hidden;
 }
 
 void PersonalNotification::setRemoteUid(const QString& remoteUid)
@@ -310,6 +335,14 @@ void PersonalNotification::setSmsReplaceNumber(const QString &number)
 {
     if (m_smsReplaceNumber != number) {
         m_smsReplaceNumber = number;
+        setHasPendingEvents(true);
+    }
+}
+
+void PersonalNotification::setHidden(bool hide)
+{
+    if (m_hidden != hide) {
+        m_hidden = hide;
         setHasPendingEvents(true);
     }
 }

--- a/src/personalnotification.h
+++ b/src/personalnotification.h
@@ -63,8 +63,12 @@ class PersonalNotification : public QObject, public Serialisable
                                   WRITE setEventToken)
     Q_PROPERTY(QString smsReplaceNumber READ smsReplaceNumber
                                         WRITE setSmsReplaceNumber)
+    Q_PROPERTY(bool hidden READ hidden
+                           WRITE setHidden)
 
 public:
+    enum EventCollection { Messaging = 0, Voicemail, Voice };
+
     PersonalNotification(QObject* parent = 0);
     PersonalNotification(const QString& remoteUid,
                          const QString& account,
@@ -86,6 +90,9 @@ public:
 
     QString notificationName() const;
 
+    EventCollection collection() const;
+    static EventCollection collection(uint eventType);
+
     QString remoteUid() const;
     QString account() const;
     uint eventType() const;
@@ -102,6 +109,7 @@ public:
     QString chatName() const;
     QString eventToken() const;
     QString smsReplaceNumber() const;
+    bool hidden() const;
 
     void setRemoteUid(const QString& remoteUid);
     void setAccount(const QString& account);
@@ -115,6 +123,7 @@ public:
     void setChatName(const QString& chatName);
     void setEventToken(const QString& eventToken);
     void setSmsReplaceNumber(const QString& number);
+    void setHidden(bool hide = true);
 
 signals:
     void hasPendingEventsChanged(bool hasPendingEvents);
@@ -132,6 +141,7 @@ private:
     QString m_chatName;
     QString m_eventToken;
     QString m_smsReplaceNumber;
+    bool m_hidden;
 
     Notification *m_notification;
 

--- a/tests/ut_notificationmanager/ut_notificationmanager.cpp
+++ b/tests/ut_notificationmanager/ut_notificationmanager.cpp
@@ -104,7 +104,8 @@ CommHistory::Event Ut_NotificationManager::createEvent(CommHistory::Event::Event
 
 PersonalNotification *Ut_NotificationManager::getNotification(const CommHistory::Event &event)
 {
-    NotificationGroup *group = nm->m_Groups.value(event.type());
+    NotificationManager::EventGroupProperties groupProperties(NotificationManager::eventGroup(PersonalNotification::collection(event.type()), event.localUid(), event.remoteUid()));
+    NotificationGroup *group = nm->m_Groups.value(groupProperties);
     foreach (PersonalNotification *pn, group->notifications()) {
         if (pn->eventToken() == event.messageToken())
             return pn;
@@ -129,7 +130,8 @@ void Ut_NotificationManager::testShowNotification()
     QTRY_VERIFY(n);
     QTRY_VERIFY(n->replacesId() > 0);
 
-    NotificationGroup *group = nm->m_Groups.value(event.type());
+    NotificationManager::EventGroupProperties groupProperties(NotificationManager::eventGroup(PersonalNotification::collection(event.type()), event.localUid(), event.remoteUid()));
+    NotificationGroup *group = nm->m_Groups.value(groupProperties);
     Notification *groupNotification = group->notification();
     QVERIFY(groupNotification);
     QVERIFY(groupNotification->replacesId() > 0);


### PR DESCRIPTION
Previously, notifications were grouped by event type, so that there would be only one visible notification per type.  Now that lipstick can support larger numbers of notifications through grouping, we can have a notification for each conversation with pending events.

Grouping now occurs for each pair of endpoints combined with the 'collection' the contained events comprise: Voice, Voicemail or Messaging.  If there are multiple notifications in a single group then the individual items are hidden; if there is only one member the group is hidden instead.