### PR TITLE
[commhistory-daemon] A pending invitation should have high priority

### DIFF
--- a/data/notifications/x-nemo.messaging.authorizationrequest.conf
+++ b/data/notifications/x-nemo.messaging.authorizationrequest.conf
@@ -3,4 +3,4 @@ x-nemo-icon=icon-lock-invitation
 x-nemo-preview-icon=icon-s-status-invitation-pending
 x-nemo-feedback=default
 x-nemo-user-removable=false
-x-nemo-priority=30
+x-nemo-priority=90


### PR DESCRIPTION
This should be the highest priority notification below those that are shown on the lock screen (priority >= 100).