### PR TITLE
Use text details from MMS send error notifications

### DIFF
--- a/src/mmshandler.cpp
+++ b/src/mmshandler.cpp
@@ -332,7 +332,7 @@ QString MmsHandler::copyMessagePartFile(const QString &sourcePath, int eventId, 
     return filePath;
 }
 
-void MmsHandler::messageSendStateChanged(const QString &recId, int state)
+void MmsHandler::messageSendStateChanged(const QString &recId, int state, const QString &details)
 {
     enum MessageSendState {
         Encoding = 0,
@@ -343,6 +343,8 @@ void MmsHandler::messageSendStateChanged(const QString &recId, int state)
         SendError,
         Refused
     };
+
+    DEBUG_("message" << recId << "state" << state << details);
 
     Event event;
     SingleEventModel model;
@@ -379,7 +381,7 @@ void MmsHandler::messageSendStateChanged(const QString &recId, int state)
 
         if (newStatus != Event::SendingStatus) {
             m_activeEvents.removeOne(event.id());
-            NotificationManager::instance()->showNotification(event, event.remoteUid(), Group::ChatTypeP2P);
+            NotificationManager::instance()->showNotification(event, event.remoteUid(), Group::ChatTypeP2P, details);
         }
     }
 }

--- a/src/mmshandler.h
+++ b/src/mmshandler.h
@@ -52,7 +52,7 @@ public Q_SLOTS:
             const QString &cls, bool readReport, MmsPartList parts);
 
     void deliveryReport(const QString &imsi, const QString &mmsId, const QString &recipient, int status);
-    void messageSendStateChanged(const QString &recId, int state);
+    void messageSendStateChanged(const QString &recId, int state, const QString &details);
     void messageSent(const QString &recId, const QString &mmsId);
     void readReport(const QString &imsi, const QString &mmsId, const QString &recipient, int status);
     void readReportSendStatus(const QString &recId, int status);

--- a/src/notificationmanager.h
+++ b/src/notificationmanager.h
@@ -2,7 +2,7 @@
 **
 ** This file is part of commhistory-daemon.
 **
-** Copyright (C) 2013 Jolla Ltd.
+** Copyright (C) 2013-2015 Jolla Ltd.
 ** Copyright (C) 2010 Nokia Corporation and/or its subsidiary(-ies).
 ** Contact: John Brooks <john.brooks@jolla.com>
 **
@@ -94,7 +94,8 @@ public:
      */
     void showNotification(const CommHistory::Event& event,
                           const QString &channelTargetId = QString(),
-                          CommHistory::Group::ChatType chatType = CommHistory::Group::ChatTypeP2P);
+                          CommHistory::Group::ChatType chatType = CommHistory::Group::ChatTypeP2P,
+                          const QString &details = QString());
 
     /*!
      * \brief removes notifications whose event type is in the supplied list of types
@@ -166,7 +167,7 @@ private:
 
     bool isFilteredInbox();
     QString filteredInboxAccountPath();
-    bool updateEditedEvent(const CommHistory::Event &event);
+    bool updateEditedEvent(const CommHistory::Event &event, const QString &text);
 
 private:
     static NotificationManager* m_pInstance;
@@ -175,7 +176,7 @@ private:
 
     QList<PersonalNotification*> m_unresolvedEvents;
 
-    QString notificationText(const CommHistory::Event &event);
+    QString notificationText(const CommHistory::Event &event, const QString &details);
 
     QSharedPointer<CommHistory::ContactListener> m_contactListener;
     CommHistory::GroupModel *m_GroupModel;

--- a/src/org.nemomobile.MmsHandler.xml
+++ b/src/org.nemomobile.MmsHandler.xml
@@ -267,6 +267,14 @@
           6 (Refused):   Operator refused to accept the message
       -->
       <arg direction="in" type="i" name="state"/>
+      <!--
+          Optional detail string. In most cases it's empty by in case
+          if the message was refused by the operator it contains the
+          value of X-Mms-Response-Text header from M-Send.conf PDU.
+          It could explain the reason for the failure and should be
+          displayed to the user.
+      -->
+      <arg direction="in" type="s" name="details"/>
     </method>
 
     <!--

--- a/tests/stubs/notificationmanager.cpp
+++ b/tests/stubs/notificationmanager.cpp
@@ -33,9 +33,10 @@ NotificationManager* NotificationManager::instance()
 
 void NotificationManager::showNotification(const CommHistory::Event& event,
                       const QString &channelTargetId,
-                      CommHistory::Group::ChatType chatType)
+                      CommHistory::Group::ChatType chatType,
+                      const QString &details)
 {
-    qDebug() << event.toString() << channelTargetId << chatType;
+    qDebug() << event.toString() << channelTargetId << chatType << details;
     Notification n;
     n.event = event;
     n.channelTargetId = channelTargetId;

--- a/tests/stubs/notificationmanager.h
+++ b/tests/stubs/notificationmanager.h
@@ -25,8 +25,8 @@ public:
     static NotificationManager* instance();
     void showNotification(const CommHistory::Event& event,
                           const QString &channelTargetId = QString(),
-                          CommHistory::Group::ChatType chatType = CommHistory::Group::ChatTypeP2P);
-
+                          CommHistory::Group::ChatType chatType = CommHistory::Group::ChatTypeP2P,
+                          const QString &details = QString());
 
     CommHistory::GroupModel* groupModel();
     void showVoicemailNotification(int count);


### PR DESCRIPTION
Fixes JB#26078

Allows to show operator's errors messages to the user. Requires https://github.com/nemomobile/mms-engine/pull/66 to actually work.