### PR TITLE
[commhistory-daemon] Update group notification timestamps correctly. Contributes to MER#923

### DIFF
--- a/src/notificationgroup.cpp
+++ b/src/notificationgroup.cpp
@@ -123,12 +123,24 @@ void NotificationGroup::updateGroup()
     if (type() != CommHistory::Event::VoicemailEvent)
         name = tempLocale.joinStringList(contactNames());
     mGroup->setSummary(name);
-    mGroup->publish();
+
+    // Find the most recent timestamp from grouped notifications
+    QDateTime groupTimestamp;
 
     foreach (PersonalNotification *pn, mNotifications) {
-        if (pn->hasPendingEvents())
+        if (pn->hasPendingEvents()) {
             pn->publishNotification();
+        }
+
+        QDateTime timestamp(pn->timestamp());
+        if (groupTimestamp.isNull() || timestamp > groupTimestamp) {
+            groupTimestamp = timestamp;
+        }
     }
+
+    mGroup->setTimestamp(groupTimestamp);
+    mGroup->publish();
+
 }
 
 void NotificationGroup::updateGroupLater()

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -107,8 +107,10 @@ void PersonalNotification::publishNotification()
     if (m_eventType != CommHistory::Event::VoicemailEvent)
         name = notificationName();
 
-    if (!m_notification)
+    if (!m_notification) {
         m_notification = new Notification(this);
+        m_notification->setTimestamp(QDateTime::currentDateTimeUtc());
+    }
 
     m_notification->setAppName(txt_qtn_msg_notifications_group);
     m_notification->setCategory(NotificationGroup::groupType(m_eventType));
@@ -216,6 +218,14 @@ QString PersonalNotification::eventToken() const
 QString PersonalNotification::smsReplaceNumber() const
 {
     return m_smsReplaceNumber;
+}
+
+QDateTime PersonalNotification::timestamp() const
+{
+    if (m_notification)
+        return m_notification->timestamp();
+
+    return QDateTime();
 }
 
 void PersonalNotification::setRemoteUid(const QString& remoteUid)

--- a/src/personalnotification.h
+++ b/src/personalnotification.h
@@ -102,6 +102,7 @@ public:
     QString chatName() const;
     QString eventToken() const;
     QString smsReplaceNumber() const;
+    QDateTime timestamp() const;
 
     void setRemoteUid(const QString& remoteUid);
     void setAccount(const QString& account);


### PR DESCRIPTION
Whenever a commhistory group notification is updated, the timestamp should be updated to reflect the most recent timestamp of the grouped notifications it represents.