### PR TITLE
[commhistory-daemon] Suppress feedback from group notification. Contributes to MER#940

### DIFF
--- a/data/notifications/x-nemo.call.missed.group.conf
+++ b/data/notifications/x-nemo.call.missed.group.conf
@@ -1,0 +1,4 @@
+appIcon=icon-lock-missed-call
+x-nemo-icon=icon-lock-missed-call
+x-nemo-priority=100
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.group.conf
+++ b/data/notifications/x-nemo.messaging.group.conf
@@ -1,6 +1,4 @@
 appIcon=icon-lock-chat
 x-nemo-icon=icon-lock-chat
-x-nemo-preview-icon=icon-s-status-chat
-x-nemo-feedback=chat
 x-nemo-priority=100
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.group.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.conf
@@ -1,0 +1,5 @@
+appIcon=icon-lock-voicemail
+x-nemo-icon=icon-lock-voicemail
+x-nemo-priority=100
+x-nemo-user-removable=false
+x-nemo-led-disabled-without-body-and-summary=false

--- a/src/notificationgroup.cpp
+++ b/src/notificationgroup.cpp
@@ -73,6 +73,38 @@ int NotificationGroup::eventType(const QString &groupType)
     return -1;
 }
 
+QString NotificationGroup::groupName(PersonalNotification::EventCollection collection)
+{
+    switch (collection) {
+        case PersonalNotification::Voicemail:
+            return txt_qtn_msg_voicemail_group;
+
+        case PersonalNotification::Voice:
+            return txt_qtn_msg_missed_calls_group;
+
+        case PersonalNotification::Messaging:
+            return txt_qtn_msg_notifications_group;
+    }
+
+    return QString();
+}
+
+QString NotificationGroup::groupCategory(PersonalNotification::EventCollection collection)
+{
+    switch (collection) {
+        case PersonalNotification::Voicemail:
+            return QStringLiteral("x-nemo.messaging.voicemail.group");
+
+        case PersonalNotification::Voice:
+            return QStringLiteral("x-nemo.call.missed.group");
+
+        case PersonalNotification::Messaging:
+            return QStringLiteral("x-nemo.messaging.group");
+    }
+
+    return QString();
+}
+
 PersonalNotification::EventCollection NotificationGroup::collection() const
 {
     return m_collection;
@@ -111,12 +143,13 @@ void NotificationGroup::updateGroup()
     if (!mGroup)
         mGroup = new Notification(this);
 
-    mGroup->setAppName(txt_qtn_msg_notifications_group);
-    mGroup->setCategory("x-nemo.messaging.group");
+    mGroup->setAppName(groupName(m_collection));
+    mGroup->setCategory(groupCategory(m_collection));
     mGroup->setSummary(mLocale.joinStringList(contactNames()));
     mGroup->setBody(notificationGroupText());
     mGroup->setItemCount(mNotifications.size());
     mGroup->setHintValue("x-nemo-hidden", mNotifications.size() < 2);
+
     NotificationManager::instance()->setNotificationProperties(mGroup, mNotifications[0],
             countConversations() > 1);
 

--- a/src/notificationgroup.h
+++ b/src/notificationgroup.h
@@ -50,6 +50,9 @@ public:
     static QString groupType(int eventType);
     static int eventType(const QString &groupType);
 
+    static QString groupName(PersonalNotification::EventCollection collection);
+    static QString groupCategory(PersonalNotification::EventCollection collection);
+
     PersonalNotification::EventCollection collection() const;
     const QString &localUid() const;
     const QString &remoteUid() const;

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -550,13 +550,10 @@ static QVariantMap dbusAction(const QString &name, const QString &service, const
 
 void NotificationManager::setNotificationProperties(Notification *notification, PersonalNotification *pn, bool grouped)
 {
-    QString appName;
     QVariantList remoteActions;
 
     switch (pn->collection()) {
         case PersonalNotification::Messaging:
-
-            appName = txt_qtn_msg_notifications_group;
 
             if (pn->eventType() != VOICEMAIL_SMS_EVENT_TYPE && grouped) {
                 remoteActions.append(dbusAction("default",
@@ -584,8 +581,6 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
 
         case PersonalNotification::Voice:
 
-            appName = txt_qtn_msg_missed_calls_group;
-
             remoteActions.append(dbusAction("default",
                                             CALL_HISTORY_SERVICE_NAME,
                                             CALL_HISTORY_OBJECT_PATH,
@@ -602,8 +597,6 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
 
         case PersonalNotification::Voicemail:
 
-            appName = txt_qtn_msg_voicemail_group;
-
             remoteActions.append(dbusAction("default",
                                             CALL_HISTORY_SERVICE_NAME,
                                             VOICEMAIL_OBJECT_PATH,
@@ -617,7 +610,6 @@ void NotificationManager::setNotificationProperties(Notification *notification, 
             break;
     }
 
-    notification->setAppName(appName);
     notification->setRemoteActions(remoteActions);
 }
 

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -114,10 +114,11 @@ void PersonalNotification::publishNotification()
         m_notification->setTimestamp(QDateTime::currentDateTimeUtc());
     }
 
-    m_notification->setAppName(txt_qtn_msg_notifications_group);
+    m_notification->setAppName(NotificationGroup::groupName(collection()));
     m_notification->setCategory(NotificationGroup::groupType(m_eventType));
     m_notification->setHintValue("x-commhistoryd-data", serialized().toBase64());
     m_notification->setHintValue("x-nemo-hidden", m_hidden);
+
     NotificationManager::instance()->setNotificationProperties(m_notification, this, false);
 
     // No preview banner for existing notifications


### PR DESCRIPTION
Feedback is generated from individual event notifications; the group notification should not have any associated feedback.  Also create separate categories for the different types of groupings. 