### PR TITLE
[commhistory-daemon] Store timestamp in commhistory notifications. Contributes to MER#1036

### DIFF
--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -223,7 +223,7 @@ void NotificationManager::showNotification(const CommHistory::Event& event,
     }
 
     PersonalNotification *notification = new PersonalNotification(event.remoteUid(),
-            event.localUid(), event.type(), channelTargetId, chatType);
+            event.localUid(), event.type(), channelTargetId, chatType, event.startTime());
     notification->setNotificationText(text);
     notification->setSmsReplaceNumber(event.headers().value(REPLACE_TYPE));
 

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -48,13 +48,14 @@ PersonalNotification::PersonalNotification(const QString& remoteUid,
                                            CommHistory::Event::EventType eventType,
                                            const QString& channelTargetId,
                                            CommHistory::Group::ChatType chatType,
+                                           const QDateTime& timestamp,
                                            uint contactId,
                                            const QString& lastNotification,
                                           QObject* parent) :
     QObject(parent), m_remoteUid(remoteUid), m_account(account),
     m_eventType(eventType), m_targetId(channelTargetId), m_chatType(chatType),
     m_contactId(contactId), m_notificationText(lastNotification),
-    m_hasPendingEvents(true),
+    m_hasPendingEvents(true), m_timestamp(timestamp),
     m_hidden(false),
     m_notification(0)
 {
@@ -109,10 +110,8 @@ void PersonalNotification::publishNotification()
     if (m_eventType != CommHistory::Event::VoicemailEvent)
         name = notificationName();
 
-    if (!m_notification) {
+    if (!m_notification)
         m_notification = new Notification(this);
-        m_notification->setTimestamp(QDateTime::currentDateTimeUtc());
-    }
 
     m_notification->setAppName(NotificationGroup::groupName(collection()));
     m_notification->setCategory(NotificationGroup::groupType(m_eventType));
@@ -132,6 +131,7 @@ void PersonalNotification::publishNotification()
 
     m_notification->setSummary(name);
     m_notification->setBody(notificationText());
+    m_notification->setTimestamp(m_timestamp);
 
     m_notification->publish();
 
@@ -243,10 +243,7 @@ QString PersonalNotification::smsReplaceNumber() const
 
 QDateTime PersonalNotification::timestamp() const
 {
-    if (m_notification)
-        return m_notification->timestamp();
-
-    return QDateTime();
+    return m_timestamp;
 }
 
 bool PersonalNotification::hidden() const
@@ -346,6 +343,14 @@ void PersonalNotification::setSmsReplaceNumber(const QString &number)
 {
     if (m_smsReplaceNumber != number) {
         m_smsReplaceNumber = number;
+        setHasPendingEvents(true);
+    }
+}
+
+void PersonalNotification::setTimestamp(const QDateTime &timestamp)
+{
+    if (m_timestamp != timestamp) {
+        m_timestamp = timestamp;
         setHasPendingEvents(true);
     }
 }

--- a/src/personalnotification.h
+++ b/src/personalnotification.h
@@ -65,6 +65,8 @@ class PersonalNotification : public QObject, public Serialisable
                                         WRITE setSmsReplaceNumber)
     Q_PROPERTY(bool hidden READ hidden
                            WRITE setHidden)
+    Q_PROPERTY(QDateTime timestamp READ timestamp
+                                   WRITE setTimestamp)
 
 public:
     enum EventCollection { Messaging = 0, Voicemail, Voice };
@@ -75,6 +77,7 @@ public:
                          CommHistory::Event::EventType eventType = CommHistory::Event::UnknownType,
                          const QString& targetId = QString(),
                          CommHistory::Group::ChatType chatType = CommHistory::Group::ChatTypeP2P,
+                         const QDateTime& timestamp = QDateTime(),
                          uint contactId = 0,
                          const QString& lastNotification = QString(),
                          QObject* parent = 0);
@@ -124,6 +127,7 @@ public:
     void setChatName(const QString& chatName);
     void setEventToken(const QString& eventToken);
     void setSmsReplaceNumber(const QString& number);
+    void setTimestamp(const QDateTime& timestamp);
     void setHidden(bool hide = true);
 
 signals:
@@ -142,6 +146,7 @@ private:
     QString m_chatName;
     QString m_eventToken;
     QString m_smsReplaceNumber;
+    QDateTime m_timestamp;
     bool m_hidden;
 
     Notification *m_notification;


### PR DESCRIPTION
Store the timestamp of individual notifications rather than relying on the notification timestamp which can be modified by the server.