### PR TITLE
[commhistory-daemon] Raise messaging notification priorities. Contributes to MER#1069

### DIFF
--- a/data/notifications/x-nemo.call.missed.conf
+++ b/data/notifications/x-nemo.call.missed.conf
@@ -2,5 +2,5 @@ appIcon=icon-lock-missed-call
 x-nemo-icon=icon-lock-missed-call
 x-nemo-preview-icon=icon-lock-missed-call
 x-nemo-feedback=call
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.call.missed.group.conf
+++ b/data/notifications/x-nemo.call.missed.group.conf
@@ -1,4 +1,4 @@
 appIcon=icon-lock-missed-call
 x-nemo-icon=icon-lock-missed-call
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.group.conf
+++ b/data/notifications/x-nemo.messaging.group.conf
@@ -1,4 +1,4 @@
 appIcon=icon-lock-sms
 x-nemo-icon=icon-lock-sms
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.im.conf
+++ b/data/notifications/x-nemo.messaging.im.conf
@@ -2,5 +2,5 @@ appIcon=icon-lock-sms
 x-nemo-icon=icon-lock-sms
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-feedback=chat
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.mms.conf
+++ b/data/notifications/x-nemo.messaging.mms.conf
@@ -2,5 +2,5 @@ appIcon=icon-lock-sms
 x-nemo-icon=icon-lock-sms
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-feedback=sms
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.sms.conf
+++ b/data/notifications/x-nemo.messaging.sms.conf
@@ -2,5 +2,5 @@ appIcon=icon-lock-sms
 x-nemo-icon=icon-lock-sms
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-feedback=sms
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.conf
@@ -1,6 +1,6 @@
 appIcon=icon-lock-sms
 x-nemo-icon=icon-lock-sms
 x-nemo-preview-icon=icon-lock-sms
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-feedback=sms
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -3,5 +3,5 @@ x-nemo-icon=icon-lock-voicemail
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-user-removable=false
 x-nemo-feedback=sms
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.group.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.conf
@@ -1,5 +1,5 @@
 appIcon=icon-lock-voicemail
 x-nemo-icon=icon-lock-voicemail
-x-nemo-priority=100
+x-nemo-priority=120
 x-nemo-user-removable=false
 x-nemo-led-disabled-without-body-and-summary=false


### PR DESCRIPTION
Messaging notifications should be more prominent than email.