### PR TITLE
[commhistory-daemon] Turn on display for urgent notifications. Contributes to MER#1076

### DIFF
--- a/data/notifications/x-nemo.messaging.im.conf
+++ b/data/notifications/x-nemo.messaging.im.conf
@@ -4,3 +4,4 @@ x-nemo-preview-icon=icon-lock-sms
 x-nemo-feedback=chat
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.mms.conf
+++ b/data/notifications/x-nemo.messaging.mms.conf
@@ -4,3 +4,4 @@ x-nemo-preview-icon=icon-lock-sms
 x-nemo-feedback=sms
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.sms.conf
+++ b/data/notifications/x-nemo.messaging.sms.conf
@@ -4,3 +4,4 @@ x-nemo-preview-icon=icon-lock-sms
 x-nemo-feedback=sms
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.conf
@@ -4,3 +4,4 @@ x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-feedback=sms
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-waiting.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-waiting.conf
@@ -5,3 +5,4 @@ x-nemo-user-removable=false
 x-nemo-feedback=sms
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -5,3 +5,4 @@ x-nemo-user-removable=false
 x-nemo-feedback=sms
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-display-on=true

--- a/src/notificationmanager.cpp
+++ b/src/notificationmanager.cpp
@@ -237,14 +237,6 @@ void NotificationManager::showNotification(const CommHistory::Event& event,
     notification->setEventToken(event.messageToken());
 
     resolveNotification(notification);
-
-    if (event.type() == CommHistory::Event::SMSEvent ||
-        event.type() == CommHistory::Event::MMSEvent) {
-        // ask mce to undim the screen
-        QString mceMethod = QString::fromLatin1(MCE_DISPLAY_ON_REQ);
-        QDBusMessage msg = QDBusMessage::createMethodCall(MCE_SERVICE, MCE_REQUEST_PATH, MCE_REQUEST_IF, mceMethod);
-        QDBusConnection::systemBus().call(msg, QDBus::NoBlock);
-    }
 }
 
 void NotificationManager::resolveNotification(PersonalNotification *pn)


### PR DESCRIPTION
Urgent notifications should use the x-nemo-display-on hint to request the display to be turned on if required.