### PR TITLE
[commhistory-daemon] Use summary-only presentation for missed calls. Contributes to MER#1087

### DIFF
--- a/data/notifications/x-nemo.call.missed.conf
+++ b/data/notifications/x-nemo.call.missed.conf
@@ -4,3 +4,4 @@ x-nemo-preview-icon=icon-lock-missed-call
 x-nemo-feedback=call
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-max-content-lines=1

--- a/data/notifications/x-nemo.call.missed.group.conf
+++ b/data/notifications/x-nemo.call.missed.group.conf
@@ -2,3 +2,4 @@ appIcon=icon-lock-missed-call
 x-nemo-icon=icon-lock-missed-call
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-max-content-lines=1

--- a/data/notifications/x-nemo.messaging.voicemail-waiting.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-waiting.conf
@@ -6,3 +6,4 @@ x-nemo-feedback=sms
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true
+x-nemo-max-content-lines=1

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -6,3 +6,4 @@ x-nemo-feedback=sms
 x-nemo-priority=120
 x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true
+x-nemo-max-content-lines=1

--- a/data/notifications/x-nemo.messaging.voicemail.group.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.conf
@@ -3,3 +3,4 @@ x-nemo-icon=icon-lock-voicemail
 x-nemo-priority=120
 x-nemo-user-removable=false
 x-nemo-led-disabled-without-body-and-summary=false
+x-nemo-max-content-lines=1


### PR DESCRIPTION
Notifications for missed calls and voicemails should request summary-only presentation style.