### PR TITLE
[commhistory-daemon] Ensure closed notifications are removed. Contributes to MER#1106

### DIFF
--- a/src/notificationgroup.h
+++ b/src/notificationgroup.h
@@ -90,6 +90,8 @@ signals:
 
 private slots:
     void onNotificationChanged();
+    void onNotificationClosed(PersonalNotification *);
+    void onClosed(uint);
 
 private:
     PersonalNotification::EventCollection m_collection;

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -87,6 +87,7 @@ bool PersonalNotification::restore(Notification *n)
         return false;
 
     m_notification = n;
+    connect(m_notification, SIGNAL(closed(uint)), SLOT(onClosed(uint)));
     return true;
 }
 
@@ -111,6 +112,8 @@ void PersonalNotification::publishNotification()
 
     if (!m_notification) {
         m_notification = new Notification(this);
+        connect(m_notification, SIGNAL(closed(uint)), SLOT(onClosed(uint)));
+
         m_notification->setTimestamp(QDateTime::currentDateTimeUtc());
     }
 
@@ -143,10 +146,11 @@ void PersonalNotification::publishNotification()
 void PersonalNotification::removeNotification()
 {
     DEBUG() << "removing notification" << m_notification;
-    if (m_notification)
+    if (m_notification) {
         m_notification->close();
-    delete m_notification;
-    m_notification = 0;
+        m_notification->deleteLater();
+        m_notification = 0;
+    }
 
     setHasPendingEvents(false);
 }
@@ -356,6 +360,11 @@ void PersonalNotification::setHidden(bool hide)
         m_hidden = hide;
         setHasPendingEvents(true);
     }
+}
+
+void PersonalNotification::onClosed(uint /*reason*/)
+{
+    emit notificationClosed(this);
 }
 
 QDataStream& operator<<(QDataStream &out, const RTComLogger::PersonalNotification &key)

--- a/src/personalnotification.h
+++ b/src/personalnotification.h
@@ -128,6 +128,10 @@ public:
 
 signals:
     void hasPendingEventsChanged(bool hasPendingEvents);
+    void notificationClosed(PersonalNotification *);
+
+private slots:
+    void onClosed(uint);
 
 private:
     QString m_remoteUid;


### PR DESCRIPTION
When notifications are closed by the notification server, remove them from our notification records.