### PR TITLE
[commhistory-daemon] Attach feedback to persistent notification. Contributes to MER#1113

### DIFF
--- a/data/notifications/x-nemo.call.missed.conf
+++ b/data/notifications/x-nemo.call.missed.conf
@@ -1,4 +1,7 @@
 appIcon=icon-lock-missed-call
+urgency=2
 x-nemo-icon=icon-lock-missed-call
 x-nemo-priority=120
 x-nemo-max-content-lines=1
+x-nemo-feedback=call
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.call.missed.group.conf
+++ b/data/notifications/x-nemo.call.missed.group.conf
@@ -1,4 +1,7 @@
 appIcon=icon-lock-missed-call
+urgency=2
 x-nemo-icon=icon-lock-missed-call
 x-nemo-priority=120
 x-nemo-max-content-lines=1
+x-nemo-feedback=call
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.call.missed.group.preview.conf
+++ b/data/notifications/x-nemo.call.missed.group.preview.conf
@@ -1,6 +1,4 @@
 appIcon=icon-lock-missed-call
 transient=true
 x-nemo-preview-icon=icon-lock-missed-call
-x-nemo-feedback=call
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.call.missed.preview.conf
+++ b/data/notifications/x-nemo.call.missed.preview.conf
@@ -1,6 +1,4 @@
 appIcon=icon-lock-missed-call
 transient=true
 x-nemo-preview-icon=icon-lock-missed-call
-x-nemo-feedback=call
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.group.conf
+++ b/data/notifications/x-nemo.messaging.group.conf
@@ -1,3 +1,6 @@
 appIcon=icon-lock-sms
+urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=sms
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.group.preview.conf
@@ -1,7 +1,5 @@
 appIcon=icon-lock-sms
 transient=true
 x-nemo-preview-icon=icon-lock-sms
-x-nemo-feedback=sms
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.group.preview.conf
@@ -1,5 +1,6 @@
 appIcon=icon-lock-sms
 transient=true
+urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.im.conf
+++ b/data/notifications/x-nemo.messaging.im.conf
@@ -1,4 +1,7 @@
 appIcon=icon-lock-sms
+urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-max-content-lines=6
+x-nemo-feedback=chat
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.im.preview.conf
+++ b/data/notifications/x-nemo.messaging.im.preview.conf
@@ -1,7 +1,5 @@
 appIcon=icon-lock-sms
 transient=true
 x-nemo-preview-icon=icon-lock-sms
-x-nemo-feedback=chat
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.im.preview.conf
+++ b/data/notifications/x-nemo.messaging.im.preview.conf
@@ -1,5 +1,6 @@
 appIcon=icon-lock-sms
 transient=true
+urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.mms.conf
+++ b/data/notifications/x-nemo.messaging.mms.conf
@@ -1,4 +1,7 @@
 appIcon=icon-lock-sms
+urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-max-content-lines=6
+x-nemo-feedback=sms
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.mms.preview.conf
+++ b/data/notifications/x-nemo.messaging.mms.preview.conf
@@ -1,7 +1,5 @@
 appIcon=icon-lock-sms
 transient=true
 x-nemo-preview-icon=icon-lock-sms
-x-nemo-feedback=sms
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.mms.preview.conf
+++ b/data/notifications/x-nemo.messaging.mms.preview.conf
@@ -1,5 +1,6 @@
 appIcon=icon-lock-sms
 transient=true
+urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.sms.conf
+++ b/data/notifications/x-nemo.messaging.sms.conf
@@ -1,4 +1,7 @@
 appIcon=icon-lock-sms
+urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-max-content-lines=6
+x-nemo-feedback=sms
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.sms.preview.conf
+++ b/data/notifications/x-nemo.messaging.sms.preview.conf
@@ -1,7 +1,5 @@
 appIcon=icon-lock-sms
 transient=true
 x-nemo-preview-icon=icon-lock-sms
-x-nemo-feedback=sms
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.sms.preview.conf
+++ b/data/notifications/x-nemo.messaging.sms.preview.conf
@@ -1,5 +1,6 @@
 appIcon=icon-lock-sms
 transient=true
+urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.conf
@@ -1,3 +1,6 @@
 appIcon=icon-lock-sms
+urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=sms
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
@@ -2,6 +2,4 @@ appIcon=icon-lock-sms
 transient=true
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
-x-nemo-feedback=sms
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
@@ -1,5 +1,6 @@
 appIcon=icon-lock-sms
 transient=true
+urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -1,5 +1,8 @@
 appIcon=icon-lock-voicemail
+urgency=2
 x-nemo-icon=icon-lock-voicemail
 x-nemo-user-removable=false
 x-nemo-priority=120
 x-nemo-max-content-lines=1
+x-nemo-feedback=sms
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.group.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.conf
@@ -1,5 +1,8 @@
 appIcon=icon-lock-voicemail
+urgency=2
 x-nemo-icon=icon-lock-voicemail
 x-nemo-priority=120
 x-nemo-user-removable=false
 x-nemo-max-content-lines=1
+x-nemo-feedback=sms
+x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
@@ -1,4 +1,5 @@
 appIcon=icon-lock-voicemail
+urgency=2
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
@@ -1,6 +1,4 @@
 appIcon=icon-lock-voicemail
 x-nemo-preview-icon=icon-lock-voicemail
-x-nemo-feedback=sms
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
@@ -1,4 +1,5 @@
 appIcon=icon-lock-voicemail
+transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-priority=120

--- a/data/notifications/x-nemo.messaging.voicemail.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.preview.conf
@@ -1,4 +1,5 @@
 appIcon=icon-lock-voicemail
+urgency=2
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-priority=120
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.preview.conf
@@ -1,6 +1,4 @@
 appIcon=icon-lock-voicemail
 x-nemo-preview-icon=icon-lock-voicemail
-x-nemo-feedback=sms
 x-nemo-priority=120
-x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.preview.conf
@@ -1,4 +1,5 @@
 appIcon=icon-lock-voicemail
+transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-priority=120


### PR DESCRIPTION
If feedback is attached to the transient notification, it causes the LED feedback to be suppressed because the notification is removed after display.