### PR TITLE
[commhistory-daemon] Remove missed call notification preview. Contributes to MER#1117

### DIFF
--- a/data/notifications/x-nemo.call.missed.group.preview.conf
+++ b/data/notifications/x-nemo.call.missed.group.preview.conf
@@ -1,4 +1,0 @@
-appIcon=icon-lock-missed-call
-transient=true
-x-nemo-preview-icon=icon-lock-missed-call
-x-nemo-priority=120

--- a/data/notifications/x-nemo.call.missed.preview.conf
+++ b/data/notifications/x-nemo.call.missed.preview.conf
@@ -1,4 +1,0 @@
-appIcon=icon-lock-missed-call
-transient=true
-x-nemo-preview-icon=icon-lock-missed-call
-x-nemo-priority=120

--- a/src/notificationgroup.cpp
+++ b/src/notificationgroup.cpp
@@ -178,8 +178,9 @@ void NotificationGroup::updateGroup()
     }
     mGroup->setTimestamp(groupTimestamp);
 
-    if (membersHidden && !allRestored) {
-        // Show a preview banner for this group update (unless we've just restored from storage)
+    // Show preview banner for this group update unless we've just restored from storage
+    // (missed calls have no preview as the incoming call dialog was just shown)
+    if ((m_collection != PersonalNotification::Voice) && membersHidden && !allRestored) {
         Notification preview;
 
         preview.setAppName(mGroup->appName());

--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -129,8 +129,9 @@ void PersonalNotification::publishNotification()
 
     NotificationManager::instance()->setNotificationProperties(m_notification, this, false);
 
-    if (!m_hidden && m_notification->replacesId() == 0) {
-        // Show preview banner for notifications not previously reported
+    // Show preview banner for notifications not previously reported
+    // (missed calls have no preview as the incoming call dialog was just shown)
+    if ((collection() != Voice) && !m_hidden && m_notification->replacesId() == 0) {
         Notification preview;
 
         preview.setAppName(m_notification->appName());


### PR DESCRIPTION
Missed call notification previews are redundant due to the incoming call dialog showing the same information.