### PR TITLE
[commhistoryd] Separate notification feedback into independent events. Contributes to MER#1138

### DIFF
--- a/data/notifications/x-nemo.call.missed.conf
+++ b/data/notifications/x-nemo.call.missed.conf
@@ -3,5 +3,5 @@ urgency=2
 x-nemo-icon=icon-lock-missed-call
 x-nemo-priority=120
 x-nemo-max-content-lines=1
-x-nemo-feedback=call
+x-nemo-feedback=call_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.call.missed.group.conf
+++ b/data/notifications/x-nemo.call.missed.group.conf
@@ -3,5 +3,5 @@ urgency=2
 x-nemo-icon=icon-lock-missed-call
 x-nemo-priority=120
 x-nemo-max-content-lines=1
-x-nemo-feedback=call
+x-nemo-feedback=call_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.group.conf
+++ b/data/notifications/x-nemo.messaging.group.conf
@@ -2,5 +2,5 @@ appIcon=icon-lock-sms
 urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
-x-nemo-feedback=sms
+x-nemo-feedback=sms_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.group.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=sms
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.im.conf
+++ b/data/notifications/x-nemo.messaging.im.conf
@@ -3,5 +3,5 @@ urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-max-content-lines=6
-x-nemo-feedback=chat
+x-nemo-feedback=chat_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.im.preview.conf
+++ b/data/notifications/x-nemo.messaging.im.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=chat
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.mms.conf
+++ b/data/notifications/x-nemo.messaging.mms.conf
@@ -3,5 +3,5 @@ urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-max-content-lines=6
-x-nemo-feedback=sms
+x-nemo-feedback=sms_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.mms.preview.conf
+++ b/data/notifications/x-nemo.messaging.mms.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=sms
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.sms.conf
+++ b/data/notifications/x-nemo.messaging.sms.conf
@@ -3,5 +3,5 @@ urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
 x-nemo-max-content-lines=6
-x-nemo-feedback=sms
+x-nemo-feedback=sms_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.sms.preview.conf
+++ b/data/notifications/x-nemo.messaging.sms.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=sms
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.conf
@@ -2,5 +2,5 @@ appIcon=icon-lock-sms
 urgency=2
 x-nemo-icon=icon-lock-sms
 x-nemo-priority=120
-x-nemo-feedback=sms
+x-nemo-feedback=sms_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-SMS.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-sms
 x-nemo-priority=120
+x-nemo-feedback=sms
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail-waiting.conf
+++ b/data/notifications/x-nemo.messaging.voicemail-waiting.conf
@@ -1,9 +1,9 @@
 appIcon=icon-lock-voicemail
 x-nemo-icon=icon-lock-voicemail
 x-nemo-preview-icon=icon-lock-voicemail
-x-nemo-user-removable=false
-x-nemo-feedback=sms
 x-nemo-priority=120
+x-nemo-max-content-lines=1
+x-nemo-user-removable=false
+x-nemo-feedback=sms,sms_exists
 x-nemo-led-disabled-without-body-and-summary=false
 x-nemo-display-on=true
-x-nemo-max-content-lines=1

--- a/data/notifications/x-nemo.messaging.voicemail.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.conf
@@ -4,5 +4,5 @@ x-nemo-icon=icon-lock-voicemail
 x-nemo-user-removable=false
 x-nemo-priority=120
 x-nemo-max-content-lines=1
-x-nemo-feedback=sms
+x-nemo-feedback=sms_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.group.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.conf
@@ -4,5 +4,5 @@ x-nemo-icon=icon-lock-voicemail
 x-nemo-priority=120
 x-nemo-user-removable=false
 x-nemo-max-content-lines=1
-x-nemo-feedback=sms
+x-nemo-feedback=sms_exists
 x-nemo-led-disabled-without-body-and-summary=false

--- a/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.group.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-priority=120
+x-nemo-feedback=sms
 x-nemo-display-on=true

--- a/data/notifications/x-nemo.messaging.voicemail.preview.conf
+++ b/data/notifications/x-nemo.messaging.voicemail.preview.conf
@@ -3,4 +3,5 @@ transient=true
 urgency=2
 x-nemo-preview-icon=icon-lock-voicemail
 x-nemo-priority=120
+x-nemo-feedback=sms
 x-nemo-display-on=true


### PR DESCRIPTION
The feedback triggered for the notification of an instantaneous event should be handled separately to the feedback conveying the continuing existence of a noteworthy condition.