### PR TITLE
Purge pending message ids when channel gets closed.

### DIFF
--- a/src/channellistener.h
+++ b/src/channellistener.h
@@ -76,7 +76,7 @@ public Q_SLOTS:
     /*!
      * \brief emits channelClosed signal
      */
-    void closed();
+    virtual void closed();
 
 Q_SIGNALS:
     /*!

--- a/src/textchannellistener.cpp
+++ b/src/textchannellistener.cpp
@@ -1930,6 +1930,12 @@ void TextChannelListener::tryToClose()
     }
 }
 
+void TextChannelListener::closed()
+{
+    m_pendingMessageIds.remove(m_Channel->objectPath());
+    ChannelListener::closed();
+}
+
 void TextChannelListener::finishedWithError(const QString& errorName,
                                             const QString& errorMessage)
 {

--- a/src/textchannellistener.h
+++ b/src/textchannellistener.h
@@ -162,6 +162,7 @@ private:
 
     bool hasPendingOperations() const;
     void tryToClose();
+    void closed();
 
     CommHistory::Group getGroupById(int groupId) const;
 


### PR DESCRIPTION
Running `jolla-messages` (a telepathy ring client) used to keep the ring text channel alive all the time. These days it's started by D-Bus daemon every time the channel is created. Then it immediately exits, failing a D-Bus request or two in the process, and the channel gets destroyed before the message is acknowledged. But `commhistoryd` doesn't really care whether it's acknowledged or not. Perhaps, it's `commhistoryd` who should be client of the telepathy ring channel.

This patch makes this sub-optimal scenario work by purging `m_pendingMessageIds` when the channel gets closed.