### PR TITLE
[commhistoryd] Correctly restore notifications in older serialization format. Fixes MER#1273

### DIFF
--- a/src/personalnotification.cpp
+++ b/src/personalnotification.cpp
@@ -392,6 +392,12 @@ QDataStream& operator<<(QDataStream &out, const RTComLogger::PersonalNotificatio
 QDataStream& operator>>(QDataStream &in, RTComLogger::PersonalNotification &key)
 {
     key.deSerialize(in, key);
+
+    // Hidden property is not in the serialization from earlier forms
+    if (!key.property("hidden").isValid()) {
+        key.setProperty("hidden", QVariant::fromValue(false));
+    }
+
     return in;
 }
 

--- a/src/personalnotification.h
+++ b/src/personalnotification.h
@@ -41,6 +41,9 @@ class PersonalNotification : public QObject, public Serialisable
 {
     Q_OBJECT
 
+    // These properties determine the serialization of this object; if you change
+    // them in any way, you must account for it in the serialization functions
+
     Q_PROPERTY(QString remoteuid READ remoteUid WRITE setRemoteUid)
     Q_PROPERTY(QString account READ account WRITE setAccount)
 

--- a/src/serialisable.cpp
+++ b/src/serialisable.cpp
@@ -50,7 +50,8 @@ void Serialisable::deSerialize(QDataStream& in, QObject& object)
        QMetaProperty prop = object.metaObject()->property(i);
        const char* propName = prop.name();
        QVariant variant;
-       in >> variant;
+       if (!in.atEnd())
+           in >> variant;
        object.setProperty(propName, variant);
     }
 }


### PR DESCRIPTION
Notifications stored by pre-1.1.9 commhistoryd do not contain a value for the 'hidden' property.